### PR TITLE
Adding CakeMethodAlias to the aliases

### DIFF
--- a/Cake.AzureStorage/AzureStorageAlias.cs
+++ b/Cake.AzureStorage/AzureStorageAlias.cs
@@ -6,6 +6,7 @@ using Cake.Core.IO;
 namespace Cake.AzureStorage {
     [CakeAliasCategory("AzureStorage")]
     public static class AzureStorageAlias {
+        [CakeMethodAlias]
         public static void UploadFileToBlob(this ICakeContext context, AzureStorageSettings settings, FilePath fileToUpload) {
             if (context == null) {
                 throw new ArgumentNullException(nameof(context));


### PR DESCRIPTION
Think this might be the cause of it not recognizing the AzureStorageSettings, can't find any real difference between our settings and other addins settings, the only real difference is this